### PR TITLE
Template improvements for tags of agenda items, motions and assignments

### DIFF
--- a/openslides/agenda/templates/agenda/item_row.html
+++ b/openslides/agenda/templates/agenda/item_row.html
@@ -83,5 +83,8 @@
         {% endwith %}
         <a href="{{ node|absolute_url }}">{% if node.type == node.ORGANIZATIONAL_ITEM %}<i>[{% endif %}{{ node }}{% if node.type == node.ORGANIZATIONAL_ITEM %}]</i>{% endif %}</a>
         {{ node.get_title_supplement|safe }}
+        {% for tag in node.tags.all %}
+            <span class="label">{{ tag }}</span>
+        {% endfor %}
     </div>
 </div>

--- a/openslides/agenda/templates/agenda/overview.html
+++ b/openslides/agenda/templates/agenda/overview.html
@@ -41,7 +41,7 @@
             {% endif %}
             {% if perms.core.can_manage_tags %}
                 <a href="{% url 'core_tag_list' %}" class="btn btn-mini" rel="tooltip" data-original-title="{% trans 'Manage tags' %}">
-                    <i class="icon-th"></i>
+                    <i class="icon-tags"></i>
                     <span class="optional-small"> {% trans 'Tags' %}</span>
                 </a>
             {% endif %}

--- a/openslides/agenda/templates/agenda/view.html
+++ b/openslides/agenda/templates/agenda/view.html
@@ -41,6 +41,13 @@
     </div>
     </small>
 </h1>
+
+<!-- Tags -->
+{% for tag in item.tags.all %}
+    <span class="label">{{ tag }}</span>
+{% endfor %}
+
+<!-- Title -->
 <p>
     {% if not item.content_object %}
         {{ item.text|safe }}
@@ -49,6 +56,7 @@
     {% endif %}
 </p>
 
+<!-- Comment -->
 {% if perms.agenda.can_manage_agenda %}
     {% if item.comment %}
         <h3>{% trans "Comment" %}</h3>
@@ -56,7 +64,7 @@
     {% endif %}
 {% endif %}
 
-{# List of Speakers #}
+<!-- List of Speakers -->
 <h3>{% trans "List of speakers" %} {% if item.speaker_list_closed %}<span class="label label-important">{% trans 'closed' %}</span>{% endif %}</h3>
 <p>
 {% if perms.agenda.can_manage_agenda %}

--- a/openslides/agenda/templates/search/indexes/agenda/item_text.txt
+++ b/openslides/agenda/templates/search/indexes/agenda/item_text.txt
@@ -1,2 +1,3 @@
 {{ object.title }}
 {{ object.text }}
+{{ object.tags.all }}

--- a/openslides/assignment/templates/assignment/assignment_detail.html
+++ b/openslides/assignment/templates/assignment/assignment_detail.html
@@ -50,6 +50,11 @@
     </small>
 </h1>
 
+<!-- Tags -->
+{% for tag in assignment.tags.all %}
+    <span class="optional label">{{ tag }}</span>
+{% endfor %}
+
 <div class="row-fluid">
 <div class="span9">
     <!-- Description -->

--- a/openslides/assignment/templates/assignment/assignment_list.html
+++ b/openslides/assignment/templates/assignment/assignment_list.html
@@ -23,7 +23,7 @@
         {% endif %}
         {% if perms.core.can_manage_tags %}
             <a href="{% url 'core_tag_list' %}" class="btn btn-mini" rel="tooltip" data-original-title="{% trans 'Manage tags' %}">
-                <i class="icon-th"></i>
+                <i class="icon-tags"></i>
                 <span class="optional-small"> {% trans 'Tags' %}</span>
             </a>
         {% endif %}
@@ -46,7 +46,11 @@
     </thead>
     {% for object in object_list %}
         <tr class="{% if object.is_active_slide %}activeline{% endif %}">
-            <td><a href="{{ object|absolute_url:'detail' }}">{{ object }}</a></td>
+            <td><a href="{{ object|absolute_url:'detail' }}">{{ object }}</a>
+                {% for tag in object.tags.all %}
+                    <span class="optional label">{{ tag }}</span>
+                {% endfor %}
+            </td>
             <td  class="optional">
                 <!-- posts -->
                 {% trans "Posts" context "Number of searched candidates for an election" %}:

--- a/openslides/assignment/templates/search/indexes/assignment/assignment_text.txt
+++ b/openslides/assignment/templates/search/indexes/assignment/assignment_text.txt
@@ -1,3 +1,4 @@
 {{ object.name }}
 {{ object.description }}
 {{ object.candidates }}
+{{ object.tags.all }}

--- a/openslides/core/templates/base.html
+++ b/openslides/core/templates/base.html
@@ -113,7 +113,7 @@
             <hr />
             <footer>
                 <small>
-                    &copy; Copyright 2011–2014 | Powered by <a href="http://openslides.org" target="_blank">OpenSlides</a> | <a href="{% url 'core_version' %}">Version</a>
+                    &copy; Copyright 2011–2015 | Powered by <a href="http://openslides.org" target="_blank">OpenSlides</a> | <a href="{% url 'core_version' %}">Version</a>
                 </small>
             </footer>
         </div><!--/#content-->

--- a/openslides/core/templates/core/tag_list.html
+++ b/openslides/core/templates/core/tag_list.html
@@ -5,17 +5,23 @@
 {% block title %}{% trans "Tags" %} – {{ block.super }}{% endblock %}
 
 {% block content %}
-    <h1>{% trans "Tags" %}</h1>
+    <h1>{% trans "Tags" %}
+        <small class="pull-right">
+            <a href="javascript:window.history.back()" class="btn btn-mini">
+                <i class="icon-chevron-left"></i><span class="optional-small"> {% trans "Back to overview" %}</span>
+            </a>
+        </small>
+    </h1>
 
     <div class="control-group">
-        <label for="tag-edit">Name:</label>
+        <label for="tag-edit">{% trans 'Enter new tag name' %}:</label>
         <input id="tag-edit" name="new">
         <a href="#" id="tag-save" class="btn btn-primary">{% trans 'Save' %}</a>
     </div>
 
     <table id="tag-table" class="table table-striped table-bordered">
         <tr>
-            <th>{% trans "Tag name" %}</th>
+            <th>{% trans "Tag" %}</th>
             <th class="mini_width">{% trans "Actions" %}</th>
         </tr>
         <tr id="dummy-tag" class="tag-row" style="display:none">
@@ -47,6 +53,7 @@
             </tr>
         {% endfor %}
     </table>
+    <p>{% trans "You can use these tags for agenda items, motions and elections." %}</p>
 {% endblock %}
 
 {% block javascript %}

--- a/openslides/motion/templates/motion/motion_detail.html
+++ b/openslides/motion/templates/motion/motion_detail.html
@@ -71,8 +71,6 @@
     </small>
 </h1>
 
-{{ motion.tags.all|join:', ' }}
-
 <div class="row-fluid">
 <div class="span8">
     {# TODO: show only for workflow with versioning #}
@@ -256,7 +254,9 @@
                     {% block meta_box_poll_extras %}{% endblock %}
                 </p>
         {% empty %}
+            {% if not allowed_actions.create_poll %}
             –
+            {% endif %}
         {% endfor %}
         {% if allowed_actions.create_poll %}
             <p>
@@ -268,12 +268,18 @@
         {% endwith %}
 
         <!-- Category -->
-        <h5>{% trans "Category" %}:</h5>
         {% if motion.category %}
+            <h5>{% trans "Category" %}:</h5>
             {{ motion.category }}
-        {% else %}
-            –
         {% endif %}
+
+        <!-- Tags -->
+        {% for tag in motion.tags.all %}
+            {% if forloop.first %}
+                <h5>{% trans "Tags" %}:</h5>
+            {% endif %}
+            <span class="optional label">{{ tag }}</span>
+        {% endfor %}
 
         <!-- Creation Time -->
         <h5>

--- a/openslides/motion/templates/motion/motion_list.html
+++ b/openslides/motion/templates/motion/motion_list.html
@@ -38,7 +38,7 @@
         {% endif %}
         {% if perms.core.can_manage_tags %}
             <a href="{% url 'core_tag_list' %}" class="btn btn-mini" rel="tooltip" data-original-title="{% trans 'Manage tags' %}">
-                <i class="icon-th"></i>
+                <i class="icon-tags"></i>
                 <span class="optional-small"> {% trans 'Tags' %}</span>
             </a>
         {% endif %}
@@ -72,14 +72,18 @@
     </thead>
     {% for motion in motion_list %}
         <tr class="{% if motion.is_active_slide %}activeline{% endif %}">
-            <td class="nobr">{{ motion.identifier|default:'' }}</td>
-            <td>
-                <a href="{{ motion|absolute_url }}">{{ motion.title }}</a>
+            <td class="nobr">{{ motion.identifier|default:'' }}
                 {% if motion.is_amendment %}
-                    <a class="label label-success" data-original-title="Amendment" rel="tooltip">
+                    <a class="badge badge-success" data-original-title="Amendment" rel="tooltip">
                         {{ 'motion_amendments_prefix'|get_config }}
                     </a>
                 {% endif %}
+            </td>
+            <td>
+                <a href="{{ motion|absolute_url }}">{{ motion.title }}</a>
+                {% for tag in motion.tags.all %}
+                    <span class="optional label">{{ tag }}</span>
+                {% endfor %}
             </td>
             <td class="optional">{% if motion.category %}{{ motion.category }}{% else %}–{% endif %}</td>
             <td class="optional-small"><span class="label label-info">{% trans motion.state.name %}</span></td>

--- a/openslides/motion/templates/search/indexes/motion/motion_text.txt
+++ b/openslides/motion/templates/search/indexes/motion/motion_text.txt
@@ -5,3 +5,4 @@
 {{ object.submitters }}
 {{ object.supporters }}
 {{ object.category }}
+{{ object.tags.all }}


### PR DESCRIPTION
A lot of template improvements for tags.

I added {{ object.tags.all }} to search index file of agenda, motion and assingment. But there is still a problem with building correct search index:

To reprocude:
- start with fresh db and empty whoosh-index dir
- add new tag (e.g. TODO)
- create new motion and select tag
- search for tag name "TODO" -> no results
- edit motion text and save
- search for tag name "TODO" -> one result
Same with agenda item. Tags are in search index only when object (motion) is modified/saved again.

If you exit server and rebuild the whoosh search index with `python manage.py django rebuild_index` you get an error:
`django.db.utils.OperationalError: no such table: core_tag`
This error go away if you change {{ object.tags.all }} to {{ object.tags }} in assignment_text.txt and item_text.txt. For motion it still works with objects.tags.all.

Any idea for this seach index problem?